### PR TITLE
Show help even if silent is on

### DIFF
--- a/.rbenv-gemsets
+++ b/.rbenv-gemsets
@@ -1,0 +1,2 @@
+commandable
+global

--- a/lib/commandable/commandable.rb
+++ b/lib/commandable/commandable.rb
@@ -152,7 +152,7 @@ module Commandable
         command_queue = execution_queue(argv)
         command_queue.each do |com|
           return_value = com[:proc].call
-          puts return_value unless silent
+          puts return_value if !silent || com[:method] == :help
         end
       rescue SystemExit => kernel_exit
         Kernel.exit kernel_exit.status

--- a/spec/commandable/command_line_execution_spec.rb
+++ b/spec/commandable/command_line_execution_spec.rb
@@ -50,6 +50,12 @@ describe Commandable do
           lambda{execute_queue(["fly", "navy"])}.should raise_error(Commandable::UnknownCommandError)
         end
       end
+
+      context "and even when silent is on" do
+        it "prints usage/help instructions" do
+          capture_output{Commandable.execute(["help"], :silent)}.to_s.should match(/Usage:/)
+        end
+      end
     
       context "and running commands automatically via execute" do
         


### PR DESCRIPTION
Because I want to write commands that do their own output incrementally, I turned silent on.  However this had the side-effect of disabling help.

So this change allows help to still be output, even if silent is on.
